### PR TITLE
Use query_range for log streaming

### DIFF
--- a/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
+++ b/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
@@ -75,17 +75,19 @@ func (lc *LokiClient) queryRange(uri string, ctx context.Context, c chan *LokiQu
 			if err != nil {
 				return errors.Wrapf(err, "error querying range")
 			}
-			defer resp.Body.Close() // Ensure the response body is always closed.
 
 			if resp.StatusCode != http.StatusOK {
 				body, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
 				return errors.Wrapf(err, "bad HTTP response code: %d: %s", resp.StatusCode, string(body))
 			}
 
 			var lq LokiQueryRangeResponse
 			if err := json.NewDecoder(resp.Body).Decode(&lq); err != nil {
+				resp.Body.Close()
 				return errors.Wrapf(err, "error decoding Loki response")
 			}
+			resp.Body.Close()
 
 			lc.Logger.Tracef("Got response: %+v", lq)
 			c <- &lq

--- a/pkg/acquisition/modules/loki/loki_test.go
+++ b/pkg/acquisition/modules/loki/loki_test.go
@@ -44,7 +44,7 @@ func TestConfiguration(t *testing.T) {
 			config: `
 mode: tail
 source: loki`,
-			expectedErr: "Loki query is mandatory",
+			expectedErr: "loki query is mandatory",
 			testName:    "Missing url",
 		},
 		{
@@ -53,7 +53,7 @@ mode: tail
 source: loki
 url: http://localhost:3100/
 `,
-			expectedErr: "Loki query is mandatory",
+			expectedErr: "loki query is mandatory",
 			testName:    "Missing query",
 		},
 		{
@@ -176,7 +176,7 @@ func TestConfigureDSN(t *testing.T) {
 		{
 			name:        "Empty host",
 			dsn:         "loki://",
-			expectedErr: "Empty loki host",
+			expectedErr: "empty loki host",
 		},
 		{
 			name:        "Invalid DSN",


### PR DESCRIPTION
Hello,

As mentionned by @buixor in the original PR, the `tail` endpoint is not actually designed to tail logs.

This PR uses the `query_range` endpoint to get batches of logs and move a sliding window to always get the last batch.